### PR TITLE
Add status & paymentId optional in appointments

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,9 +27,10 @@ model Appointment {
   createdDate     DateTime @default(now())
   updatedAt       DateTime @updatedAt
   appointmentDate DateTime
+  status          String?
 
-  payment   Payment @relation(fields: [paymentId], references: [id])
-  paymentId String  @unique @db.Uuid // cada valor de paymentId debe ser único en la base de datos y se almacena como un identificador UUID
+  payment   Payment? @relation(fields: [paymentId], references: [id])
+  paymentId String?  @unique @db.Uuid // cada valor de paymentId debe ser único en la base de datos y se almacena como un identificador UUID
 }
 
 model Payment {


### PR DESCRIPTION
Modifications in prisma schema for appointment entity:
Added status field.
Made paymentId field optional.

Requires npx prisma deb push...